### PR TITLE
ci: run native examples in CI workflows

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -145,11 +145,14 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust/
 
-      - name: Check examples
+      - name: Run examples
         shell: devenv shell bash -- -e {0}
         run: |
           if [ -n "${{ matrix.target }}" ]; then
             cargo check --examples --target "${{ matrix.target }}" --features "${{ matrix.features }}"
           else
             cargo check --examples --features "${{ matrix.features }}"
+            cargo run --example basic_usage --features "${{ matrix.features }}"
+            cargo run --example jwt_verify --features "${{ matrix.features }}"
+            cargo run --example http_fetch --features "${{ matrix.features }}"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,10 +143,13 @@ jobs:
         if: matrix.target == 'wasm32-unknown-unknown'
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Check examples
+      - name: Run examples
         run: |
           if [ -n "${{ matrix.target }}" ]; then
             cargo check --examples --target "${{ matrix.target }}" --features "${{ matrix.features }}"
           else
             cargo check --examples --features "${{ matrix.features }}"
+            cargo run --example basic_usage --features "${{ matrix.features }}"
+            cargo run --example jwt_verify --features "${{ matrix.features }}"
+            cargo run --example http_fetch --features "${{ matrix.features }}"
           fi


### PR DESCRIPTION
## Summary
- run native examples in the examples CI job instead of only checking compilation
- execute `basic_usage`, `jwt_verify`, and `http_fetch` on native targets in both standard and nix workflows
- keep wasm behavior as compile-only checks to avoid requiring a wasm runtime in this job