### PR TITLE
ci: add cargo-audit checks and document RustSec advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -9,6 +9,26 @@ permissions:
   contents: read
 
 jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/devenv/
+        with:
+          build: "true"
+
+      - name: Set up Rust
+        uses: ./.github/actions/rust/
+
+      - name: Run cargo audit
+        shell: devenv shell bash -- -e {0}
+        run: cargo audit
+
   build:
     name: Build (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,23 @@ permissions:
   contents: read
 
 jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust
+        uses: ./.github/actions/rust/
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit
+
   build:
     name: Build (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ This crate prioritizes security:
 - **Panic-free APIs**: All fallible operations return `Result` types — standard trait implementations like `Index` follow normal Rust semantics and may panic on invalid input (e.g., out-of-bounds indexing)
 - **Input validation**: Key parameters are validated for correct sizes
 
+When enabling the optional `jwt-simple` integration, note that some `jwt-simple`
+dependency chains may pull in `rsa` versions affected by
+[`RUSTSEC-2023-0071`](https://rustsec.org/advisories/RUSTSEC-2023-0071.html)
+(Marvin timing side-channel). This primarily concerns RSA private-key
+operations (for example, signing) in attacker-observable timing contexts. If
+this matters for your deployment, prefer EdDSA/ECDSA or avoid RSA private-key
+operations until an upstream patched chain is available.
+
 ## WASM Usage
 
 Core JWKS parsing works in WebAssembly environments.

--- a/devenv.nix
+++ b/devenv.nix
@@ -31,6 +31,7 @@
   ];
 
   packages = with pkgs; [
+    cargo-audit
     cargo-release
     cargo-watch
     cargo-expand


### PR DESCRIPTION
## Summary
- add a dedicated `audit` job to both GitHub CI workflows (`ci.yaml` and `ci-nix.yaml`) to run `cargo audit`
- add `.cargo/audit.toml` with a scoped temporary ignore for `RUSTSEC-2023-0071` until an upstream patch is available
- document the `RUSTSEC-2023-0071` advisory and mitigation context in `README.md`, and add `cargo-audit` to `devenv.nix`